### PR TITLE
Fixes wrong detection of members

### DIFF
--- a/example.php
+++ b/example.php
@@ -7,7 +7,7 @@ $client = \B3none\SteamGroupChecker\Client::create();
 $response = $client->detect("76561198028510846", [
     "https://steamcommunity.com/groups/voidrealitygaming",
 ], [
-    "https://steamcommunity.com/groups/irrel",
+    "https://steamcommunity.com/groups/hentaii",
 ]);
 
 print_r([

--- a/src/Factories/GroupFactory.php
+++ b/src/Factories/GroupFactory.php
@@ -76,6 +76,8 @@ class GroupFactory
         $pages = (int)$pages;
 
         for ($pageCount = 1; $pageCount <= $pages; $pageCount++) {
+
+            $this->getXPath($this->group->getUrl(), $pageCount);
             $members = $this->xpath->xpath("/*/members/steamID64");
 
             for ($memberCount = 0; $memberCount < count($members); $memberCount++) {


### PR DESCRIPTION
If a group had more members than 1000, the first page was iterated over and over again and the first 1000 were retrieved several times. Now all members should be queried reasonably.